### PR TITLE
うごかなくなっていたため仮の修正

### DIFF
--- a/src/adapter/presentation/rest/file.go
+++ b/src/adapter/presentation/rest/file.go
@@ -98,7 +98,7 @@ func (h *Handler) UploadAdVideoHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Unable to create the video chunk file", http.StatusInternalServerError)
 		return
 	}
-	defer os.Remove(videoTempFileName)
+	// defer os.Remove(videoTempFileName)
 	defer videoDst.Close()
 
 	// 画像ファイルの内容をコピー
@@ -127,7 +127,7 @@ func (h *Handler) UploadAdVideoHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Unable to create final image file", http.StatusInternalServerError)
 			return
 		}
-		defer os.Remove(finalImageFileName)
+		// defer os.Remove(finalImageFileName)
 		defer finalImageFile.Close()
 
 		finalVideoFileName := "./uploads/" + uploadID + "_video" + "." + videoType
@@ -154,7 +154,7 @@ func (h *Handler) UploadAdVideoHandler(w http.ResponseWriter, r *http.Request) {
 			imageTempFile.Close()
 
 			// 画像チャンクファイルを削除
-			err = os.Remove(imageTempFileName)
+			// err = os.Remove(imageTempFileName)
 			if err != nil {
 				http.Error(w, "Unable to delete image chunk file", http.StatusInternalServerError)
 			}
@@ -177,7 +177,7 @@ func (h *Handler) UploadAdVideoHandler(w http.ResponseWriter, r *http.Request) {
 			videoTempFile.Close()
 
 			// 動画チャンクファイルを削除
-			os.Remove(videoTempFileName)
+			// os.Remove(videoTempFileName)
 		}
 
 		// フォームからAdVideoMetaの情報を取得

--- a/src/adapter/presentation/rest/file.go
+++ b/src/adapter/presentation/rest/file.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"strconv"
@@ -196,6 +197,7 @@ func (h *Handler) UploadAdVideoHandler(w http.ResponseWriter, r *http.Request) {
 
 		adResult, err := h.usecase.AdsInputPort.CreateAdVideo(ctx, ad, adVideo, userID, uploadID, videoType, imageType)
 		if err != nil {
+			log.Printf("Error creating ad video: %v", err)
 			http.Error(w, "Unable to process video meta", http.StatusInternalServerError)
 			return
 		}
@@ -206,9 +208,11 @@ func (h *Handler) UploadAdVideoHandler(w http.ResponseWriter, r *http.Request) {
 			AdID string `json:"adID,omitempty"`
 		}{adResult.AdID})
 		if err != nil {
+			log.Printf("Error encoding response: %v", err)
 			http.Error(w, "Unable to encode response", http.StatusInternalServerError)
 		}
 	} else {
+		log.Printf("Chunk %d uploaded", chunkNumber)
 		w.WriteHeader(http.StatusOK)
 	}
 }

--- a/src/adapter/presentation/rest/file.go
+++ b/src/adapter/presentation/rest/file.go
@@ -197,7 +197,6 @@ func (h *Handler) UploadAdVideoHandler(w http.ResponseWriter, r *http.Request) {
 
 		adResult, err := h.usecase.AdsInputPort.CreateAdVideo(ctx, ad, adVideo, userID, uploadID, videoType, imageType)
 		if err != nil {
-			log.Printf("Error creating ad video: %v", err)
 			http.Error(w, "Unable to process video meta", http.StatusInternalServerError)
 			return
 		}
@@ -212,7 +211,6 @@ func (h *Handler) UploadAdVideoHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Unable to encode response", http.StatusInternalServerError)
 		}
 	} else {
-		log.Printf("Chunk %d uploaded", chunkNumber)
 		w.WriteHeader(http.StatusOK)
 	}
 }

--- a/src/driver/router/router.go
+++ b/src/driver/router/router.go
@@ -46,7 +46,7 @@ func NewRouter() {
 	host := os.Getenv("IP") + ":" + os.Getenv("PORT")
 	fmt.Println("Server is running on " + host)
 	c := cors.New(cors.Options{
-		AllowedOrigins:   []string{"*.yuorei.com", "http://localhost:3000"},
+		AllowedOrigins:   []string{"*.yuorei.com"},
 		AllowedMethods:   []string{http.MethodGet, http.MethodPost, http.MethodDelete},
 		AllowCredentials: true,
 		AllowedHeaders:   []string{"*"},


### PR DESCRIPTION
このプル リクエストには、`src/adapter/presentation/rest/file.go` ファイルと `src/driver/router/router.go` ファイルへのいくつかの変更が含まれており、`UploadAdVideoHandler` 関数のログ機能強化と一時ファイルの処理に重点が置かれています。最も重要な変更には、エラー応答のログ機能の追加と、一時ファイルの削除のコメント アウトが含まれます。

ログ機能とエラー処理の機能強化:

* [`src/adapter/presentation/rest/file.go`](diffhunk://#diff-f9cf831953a35d301a59e3fd33629fffbdccda9766413de72ac8ddf728621c6cR210): `UploadAdVideoHandler` 関数のエンコード応答エラーのログ機能を追加しました。
* [`src/adapter/presentation/rest/file.go`](diffhunk://#diff-f9cf831953a35d301a59e3fd33629fffbdccda9766413de72ac8ddf728621c6cR7): `log` パッケージのインポートを追加しました。

一時ファイルの処理の調整:

* [`src/adapter/presentation/rest/file.go`](diffhunk://#diff-f9cf831953a35d301a59e3fd33629fffbdccda9766413de72ac8ddf728621c6cL100-R101): `UploadAdVideoHandler` 関数でビデオ チャンク ファイルの遅延削除をコメント アウトしました。
* [`src/adapter/presentation/rest/file.go`](diffhunk://#diff-f9cf831953a35d301a59e3fd33629fffbdccda9766413de72ac8ddf728621c6cL129-R130): `UploadAdVideoHandler` 関数内の最終画像ファイルの遅延削除をコメント アウトしました。
* [`src/adapter/presentation/rest/file.go`](diffhunk://#diff-f9cf831953a35d301a59e3fd33629fffbdccda9766413de72ac8ddf728621c6cL156-R157): `UploadAdVideoHandler` 関数内の画像チャンク ファイルの削除をコメント アウトしました。
* [`src/adapter/presentation/rest/file.go`](diffhunk://#diff-f9cf831953a35d301a59e3fd33629fffbdccda9766413de72ac8ddf728621c6cL179-R180): `UploadAdVideoHandler` 関数のビデオ チャンク ファイルの削除をコメント アウトしました。

許可されたオリジンへの変更:

* [`src/driver/router/router.go`](diffhunk://#diff-51ba20abc90d5435fdf74c663e4d2b2f16c087c881809e91014298c07ec9e04fL49-R49): CORS 構成の許可されたオリジンのリストから `http://localhost:3000` を削除しました。