### PR TITLE
広告とキャンペーンの一覧を取得

### DIFF
--- a/db/sqlc/organization.sql.go
+++ b/db/sqlc/organization.sql.go
@@ -31,3 +31,16 @@ func (q *Queries) CreateOrganization(ctx context.Context, arg CreateOrganization
 		arg.Category,
 	)
 }
+
+const createOrganizationUser = `-- name: CreateOrganizationUser :execresult
+insert into organizations_users (organization_id, user_id) values (?, ?)
+`
+
+type CreateOrganizationUserParams struct {
+	OrganizationID string
+	UserID         string
+}
+
+func (q *Queries) CreateOrganizationUser(ctx context.Context, arg CreateOrganizationUserParams) (sql.Result, error) {
+	return q.db.ExecContext(ctx, createOrganizationUser, arg.OrganizationID, arg.UserID)
+}

--- a/db/sqlc/sql/ads.sql
+++ b/db/sqlc/sql/ads.sql
@@ -1,3 +1,22 @@
+-- name: CheckOrganization :one
+SELECT * FROM organizations LEFT JOIN organizations_users ON organizations.organization_id = organizations_users.organization_id WHERE organizations.organization_id = ? AND organizations_users.user_id = ?;
+
+-- name: ListCampaignByOrganizationID :many
+SELECT *
+FROM campaigns AS c
+LEFT JOIN organizations_users AS ou ON c.user_id = ou.user_id
+WHERE ou.organization_id = ?
+LIMIT ? OFFSET ?;
+
+-- name: ListAds :many
+SELECT * FROM ads LIMIT ? OFFSET ?;
+
+-- name: ListAdsByCampaignID :many
+SELECT * FROM ads WHERE campaign_id = ? LIMIT ? OFFSET ?;
+
+-- name: GetAd :one
+SELECT * FROM ads WHERE ad_id = ? LIMIT 1;
+
 -- name: CreateAd :execresult
 insert into ads (ad_id, campaign_id, ad_type, is_approval,is_open,ad_link) values (?, ?, ?, ? , ?, ?);
 

--- a/db/sqlc/sql/organization.sql
+++ b/db/sqlc/sql/organization.sql
@@ -1,2 +1,5 @@
 -- name: CreateOrganization :execresult
 insert into organizations (organization_id, organization_name, representative_user_id, purpose, category) values (?, ?, ?, ?, ?);
+
+-- name: CreateOrganizationUser :execresult
+insert into organizations_users (organization_id, user_id) values (?, ?);

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/redis/go-redis/v9 v9.6.1
 	github.com/rs/cors v1.11.0
-	github.com/yuorei/yuorei-ads-proto v0.0.0-20240923010507-c5ab60067964
+	github.com/yuorei/yuorei-ads-proto v0.0.0-20250103093936-4cdc2c8b4c3a
 	golang.org/x/net v0.27.0
 	google.golang.org/api v0.190.0
 	google.golang.org/grpc v1.64.1

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/redis/go-redis/v9 v9.6.1
 	github.com/rs/cors v1.11.0
-	github.com/yuorei/yuorei-ads-proto v0.0.0-20250103093936-4cdc2c8b4c3a
+	github.com/yuorei/yuorei-ads-proto v0.0.0-20250103144532-578666cf2009
 	golang.org/x/net v0.27.0
 	google.golang.org/api v0.190.0
 	google.golang.org/grpc v1.64.1

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuorei/yuorei-ads-proto v0.0.0-20240923010507-c5ab60067964 h1:e5BK4Eyl4EX+AcfOJ1xLJTI0unWbm6KuuIJ8Hjch8es=
 github.com/yuorei/yuorei-ads-proto v0.0.0-20240923010507-c5ab60067964/go.mod h1:LJOQzwWtzllGN6WzPSOkpybdrsBQQ0mgrrJ3uP+C/4w=
+github.com/yuorei/yuorei-ads-proto v0.0.0-20250103093936-4cdc2c8b4c3a h1:H76TvfTO59odTZrILM4jv+vJ9URNLteK6So/7FyaRio=
+github.com/yuorei/yuorei-ads-proto v0.0.0-20250103093936-4cdc2c8b4c3a/go.mod h1:LJOQzwWtzllGN6WzPSOkpybdrsBQQ0mgrrJ3uP+C/4w=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=

--- a/go.sum
+++ b/go.sum
@@ -119,10 +119,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/yuorei/yuorei-ads-proto v0.0.0-20240923010507-c5ab60067964 h1:e5BK4Eyl4EX+AcfOJ1xLJTI0unWbm6KuuIJ8Hjch8es=
-github.com/yuorei/yuorei-ads-proto v0.0.0-20240923010507-c5ab60067964/go.mod h1:LJOQzwWtzllGN6WzPSOkpybdrsBQQ0mgrrJ3uP+C/4w=
-github.com/yuorei/yuorei-ads-proto v0.0.0-20250103093936-4cdc2c8b4c3a h1:H76TvfTO59odTZrILM4jv+vJ9URNLteK6So/7FyaRio=
-github.com/yuorei/yuorei-ads-proto v0.0.0-20250103093936-4cdc2c8b4c3a/go.mod h1:LJOQzwWtzllGN6WzPSOkpybdrsBQQ0mgrrJ3uP+C/4w=
+github.com/yuorei/yuorei-ads-proto v0.0.0-20250103144532-578666cf2009 h1:p7tWcFyDB5bUr9k7RzBQlhOmE+VoE+YnegsDwoH1cX0=
+github.com/yuorei/yuorei-ads-proto v0.0.0-20250103144532-578666cf2009/go.mod h1:LJOQzwWtzllGN6WzPSOkpybdrsBQQ0mgrrJ3uP+C/4w=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=

--- a/src/adapter/infrastructure/organization.go
+++ b/src/adapter/infrastructure/organization.go
@@ -34,6 +34,17 @@ func (i *Infrastructure) DBCreateOrganization(ctx context.Context, organizationI
 		return nil, err
 	}
 
+	_, err = i.db.Database.CreateOrganizationUser(ctx,
+		sqlc.CreateOrganizationUserParams{
+			OrganizationID: organization.ID,
+			UserID:         organization.RepresentativeUserID,
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
 	return organization, nil
 }
 

--- a/src/usecase/ads.go
+++ b/src/usecase/ads.go
@@ -18,6 +18,42 @@ func NewAdsRepository(adsRepository port.AdsRepository) *AdsUseCase {
 	}
 }
 
+func (r *Repository) CheckOrganizationID(ctx context.Context, organizationID, userID string) error {
+	err := r.adsRepository.adsRepository.DBCheckOrganizationID(ctx, organizationID, userID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *Repository) ListCampaignByOrganizationID(ctx context.Context, organizationID string, offset, limit int) ([]*domain.Campaign, error) {
+	result, err := r.adsRepository.adsRepository.DBListCampaignByOrganizationID(ctx, organizationID, offset, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (r *Repository) ListAdminAds(ctx context.Context, userID string, offset, limit int) ([]*domain.Ad, error) {
+	result, err := r.adsRepository.adsRepository.DBListAdminAds(ctx, userID, offset, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (r *Repository) ListAdsByCampaignID(ctx context.Context, campaignID string, offset, limit int) ([]*domain.Ad, error) {
+	result, err := r.adsRepository.adsRepository.DBListAdsByCampaignID(ctx, campaignID, offset, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 func (r *Repository) CreateCampaign(ctx context.Context, campaign *domain.Campaign) (*domain.Campaign, error) {
 	result, err := r.adsRepository.adsRepository.DBCreateCampaign(ctx, campaign)
 	if err != nil {
@@ -66,6 +102,15 @@ func (r *Repository) CreateAdVideo(ctx context.Context, ad *domain.Ad, adVideo *
 	}
 
 	return adResult, nil
+}
+
+func (r *Repository) GetAd(ctx context.Context, adID string) (*domain.Ad, error) {
+	result, err := r.adsRepository.adsRepository.DBGetAd(ctx, adID)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }
 
 func (r *Repository) GetAdVideos(ctx context.Context, req *domain.GetAdVideoRequest) ([]*domain.AdVideoResponse, error) {

--- a/src/usecase/port/ads_port.go
+++ b/src/usecase/port/ads_port.go
@@ -8,7 +8,12 @@ import (
 )
 
 type AdsInputPort interface {
+	GetAd(context.Context, string) (*domain.Ad, error)
+	CheckOrganizationID(context.Context, string, string) error
+	ListCampaignByOrganizationID(context.Context, string, int, int) ([]*domain.Campaign, error)
 	CreateCampaign(context.Context, *domain.Campaign) (*domain.Campaign, error)
+	ListAdminAds(context.Context, string, int, int) ([]*domain.Ad, error)
+	ListAdsByCampaignID(context.Context, string, int, int) ([]*domain.Ad, error)
 
 	CreateAdVideo(context.Context, *domain.Ad, *domain.AdVideo, string, string, string, string) (*domain.Ad, error)
 	GetAdVideos(context.Context, *domain.GetAdVideoRequest) ([]*domain.AdVideoResponse, error)
@@ -17,7 +22,12 @@ type AdsInputPort interface {
 }
 
 type AdsRepository interface {
+	DBGetAd(context.Context, string) (*domain.Ad, error)
+	DBCheckOrganizationID(context.Context, string, string) error
+	DBListCampaignByOrganizationID(context.Context, string, int, int) ([]*domain.Campaign, error)
+	DBListAdminAds(context.Context, string, int, int) ([]*domain.Ad, error)
 	DBCreateCampaign(context.Context, *domain.Campaign) (*domain.Campaign, error)
+	DBListAdsByCampaignID(context.Context, string, int, int) ([]*domain.Ad, error)
 
 	DBCreateAd(context.Context, *domain.Ad) (*domain.Ad, error)
 	DBCreateAdVideo(context.Context, *domain.AdVideo) (*domain.AdVideo, error)


### PR DESCRIPTION
このプル リクエストには、`db/sqlc/ads.sql.go`、`db/sqlc/organization.sql.go`、`db/sqlc/sql/ads.sql`、`db/sqlc/sql/organization.sql`、`src/adapter/infrastructure/ads.go`、`src/adapter/infrastructure/organization.go`、`src/adapter/presentation/ads.go`、および `src/usecase/ads.go` ファイルに対するいくつかの重要な変更が含まれています。これらの変更は主に、組織、キャンペーン、および広告に関連するさまざまなデータベース操作を処理するための新しい SQL クエリ、メソッド、および関数を追加します。

### 新しい SQL クエリとメソッド:

* [`db/sqlc/ads.sql.go`](diffhunk://#diff-6fe2441042e87764564efafcdca18f5c8e5904a783c9c8e26771f48cd1b4884eR11-R59): 組織の確認、広告の取得、広告の一覧表示、組織 ID によるキャンペーンの一覧表示を行うための新しい SQL クエリとメソッドが追加されました。これには、`CheckOrganization`、`GetAd`、`ListAds`、`ListAdsByCampaignID`、`ListCampaignByOrganizationID` クエリとそれに対応するメソッドが含まれます。 [[1]](diffhunk://#diff-6fe2441042e87764564efafcdca18f5c8e5904a783c9c8e26771f48cd1b4884eR11-R59) [[2]](diffhunk://#diff-6fe2441042e87764564efafcdca18f5c8e5904a783c9c8e26771f48cd1b4884eR126-R146) [[3]](diffhunk://#diff-6fe2441042e87764564efafcdca18f5c8e5904a783c9c8e26771f48cd1b4884eR228-R383)
* [[1]](diffhunk://#diff-6fe2441042e87764564efafcdca18f5c8e5904a783c9c8e26771f48cd1b4884eR11-R59) [[2]](diffhunk://#diff-6fe2441042e87764564efafcdca18f5c8e5904a783c9c8e26771f48cd1b4884eR126-R146) [[3]](diffhunk://#diff-6fe2441042e87764564efafcdca18f5c8e5904a783c9c8e26771f48cd1b4884eR228-R383)
* [`db/sqlc/organization.sql.go`](diffhunk://#diff-26255c66d209b215396bed8b222f03473c00f646983262593ee70551aa001baeR34-R46): 組織ユーザーを作成するための新しい SQL クエリとメソッドが追加されました。これには、`CreateOrganizationUser` クエリと `CreateOrganizationUser` メソッドが含まれます。

### SQL ファイルの更新:

* [`db/sqlc/sql/ads.sql`](diffhunk://#diff-f5768595b2e126c42b570827453f292863003f8bdb24a130dd9f084a04fa7917R1-R19): 組織の確認、組織 ID によるキャンペーンの一覧表示、広告の一覧表示、キャンペーン ID による広告の一覧表示、広告の取得を行うための新しい SQL クエリを追加しました。
* [`db/sqlc/sql/organization.sql`](diffhunk://#diff-ca37fc18d846e3f7c67855263804f588e00c399cd7b2a0d83b1a83bdf8e83bb6R3-R5): 組織ユーザーを作成するための新しい SQL クエリを追加しました。

### インフラストラクチャ レイヤーの機能強化:

* [`src/adapter/infrastructure/ads.go`](diffhunk://#diff-165135ec703a1718e0e10f79c4ab510a46328a705c926a7198cb9dca3df891d1R17-R130): 組織 ID の確認、組織 ID によるキャンペーンの一覧表示、管理広告の一覧表示、広告の取得、キャンペーン ID による広告の一覧表示などのデータベース操作を処理するための新しいメソッドが追加されました。 [[1]](diffhunk://#diff-165135ec703a1718e0e10f79c4ab510a46328a705c926a7198cb9dca3df891d1R17-R130) [[2]](diffhunk://#diff-165135ec703a1718e0e10f79c4ab510a46328a705c926a7198cb9dca3df891d1L79-R193) [[3]](diffhunk://#diff-165135ec703a1718e0e10f79c4ab510a46328a705c926a7198cb9dca3df891d1L103-R225) [[4]](diffhunk://#diff-165135ec703a1718e0e10f79c4ab510a46328a705c926a7198cb9dca3df891d1L132-R246) [[5]](diffhunk://#diff-165135ec703a1718e0e10f79c4ab510a46328a705c926a7198cb9dca3df891d1L184-R298)
* [`src/adapter/infrastructure/organization.go`](diffhunk://#diff-fa3ec6ceb53ea74b3143af9e1c121de943dce1b33d157a03985099b321f9b1f8R37-R47): 組織の作成方法を更新し、組織ユーザーも作成できるようにしました。

### プレゼンテーション レイヤーの機能強化:

* [`src/adapter/presentation/ads.go`](diffhunk://#diff-e685b700b84a78b9c1ee12bcfa8c8253221c94aeac27644032930fcf7924df01R26-R57): 組織 ID によるキャンペーンの一覧表示、広告の取得、管理者広告の一覧表示、キャンペーン ID による広告の一覧表示のリクエストを処理するための新しいメソッドが追加されました。 [[1]](diffhunk://#diff-e685b700b84a78b9c1ee12bcfa8c8253221c94aeac27644032930fcf7924df01R26-R57) [[2]](diffhunk://#diff-e685b700b84a78b9c1ee12bcfa8c8253221c94aeac27644032930fcf7924df01R89-R182)

### ユースケース レイヤーの強化:

* [`src/usecase/ads.go`](diffhunk://#diff-c63e8b2d33501361eb135da018885ce05bed2b662620fbb24e50bc03ee0db30aR21-R56): 組織 ID の確認、組織 ID によるキャンペーンの一覧表示、管理広告の一覧表示、キャンペーン ID による広告の一覧表示のビジネス ロジックを処理するための新しいメソッドが追加されました。

これらの変更により、組織、キャンペーン、広告をより効率的に管理およびクエリするための新しい機能が追加され、アプリケーションの機能が強化されます。