### PR TITLE
キャンペーン取得と組織取得

### DIFF
--- a/db/sqlc/ads.sql.go
+++ b/db/sqlc/ads.sql.go
@@ -225,6 +225,28 @@ func (q *Queries) GetAdVideos(ctx context.Context) ([]GetAdVideosRow, error) {
 	return items, nil
 }
 
+const getCampaign = `-- name: GetCampaign :one
+SELECT campaign_id, user_id, name, budget, start_date, end_date, created_at, updated_at, deleted_at, is_approval FROM campaigns WHERE campaign_id = ? LIMIT 1
+`
+
+func (q *Queries) GetCampaign(ctx context.Context, campaignID string) (Campaign, error) {
+	row := q.db.QueryRowContext(ctx, getCampaign, campaignID)
+	var i Campaign
+	err := row.Scan(
+		&i.CampaignID,
+		&i.UserID,
+		&i.Name,
+		&i.Budget,
+		&i.StartDate,
+		&i.EndDate,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.IsApproval,
+	)
+	return i, err
+}
+
 const listAds = `-- name: ListAds :many
 SELECT ad_id, campaign_id, ad_type, created_at, updated_at, deleted_at, is_approval, is_open, ad_link FROM ads LIMIT ? OFFSET ?
 `

--- a/db/sqlc/sql/ads.sql
+++ b/db/sqlc/sql/ads.sql
@@ -8,6 +8,9 @@ LEFT JOIN organizations_users AS ou ON c.user_id = ou.user_id
 WHERE ou.organization_id = ?
 LIMIT ? OFFSET ?;
 
+-- name: GetCampaign :one
+SELECT * FROM campaigns WHERE campaign_id = ? LIMIT 1;
+
 -- name: ListAds :many
 SELECT * FROM ads LIMIT ? OFFSET ?;
 

--- a/db/sqlc/sql/organization.sql
+++ b/db/sqlc/sql/organization.sql
@@ -1,3 +1,9 @@
+-- name: GetOrganization :one
+SELECT * FROM organizations WHERE organization_id = ?;
+
+-- name: GetOrganizationByUserID :one
+SELECT * FROM organizations LEFT JOIN organizations_users ON organizations.organization_id = organizations_users.organization_id WHERE organizations_users.user_id = ?;
+
 -- name: CreateOrganization :execresult
 insert into organizations (organization_id, organization_name, representative_user_id, purpose, category) values (?, ?, ?, ?, ?);
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/redis/go-redis/v9 v9.6.1
 	github.com/rs/cors v1.11.0
-	github.com/yuorei/yuorei-ads-proto v0.0.0-20250103144532-578666cf2009
+	github.com/yuorei/yuorei-ads-proto v0.0.0-20250106102709-7c09543b5d0f
 	golang.org/x/net v0.27.0
 	google.golang.org/api v0.190.0
 	google.golang.org/grpc v1.64.1

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/yuorei/yuorei-ads-proto v0.0.0-20250103144532-578666cf2009 h1:p7tWcFyDB5bUr9k7RzBQlhOmE+VoE+YnegsDwoH1cX0=
-github.com/yuorei/yuorei-ads-proto v0.0.0-20250103144532-578666cf2009/go.mod h1:LJOQzwWtzllGN6WzPSOkpybdrsBQQ0mgrrJ3uP+C/4w=
+github.com/yuorei/yuorei-ads-proto v0.0.0-20250106102709-7c09543b5d0f h1:hC8e9usiCPeLvBH1iTJ9gK+9MA5UN3ndhej1ev+TTkQ=
+github.com/yuorei/yuorei-ads-proto v0.0.0-20250106102709-7c09543b5d0f/go.mod h1:LJOQzwWtzllGN6WzPSOkpybdrsBQQ0mgrrJ3uP+C/4w=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=

--- a/src/adapter/infrastructure/organization.go
+++ b/src/adapter/infrastructure/organization.go
@@ -34,17 +34,6 @@ func (i *Infrastructure) DBCreateOrganization(ctx context.Context, organizationI
 		return nil, err
 	}
 
-	_, err = i.db.Database.CreateOrganizationUser(ctx,
-		sqlc.CreateOrganizationUserParams{
-			OrganizationID: organization.ID,
-			UserID:         organization.RepresentativeUserID,
-		},
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
 	return organization, nil
 }
 
@@ -54,4 +43,17 @@ func (i *Infrastructure) TmpSaveRedisCreateOrganization(ctx context.Context, org
 		return nil, err
 	}
 	return organization, nil
+}
+
+func (i *Infrastructure) DBCreateOrganizationUser(ctx context.Context, organizationID, userID string) error {
+	_, err := i.db.Database.CreateOrganizationUser(ctx,
+		sqlc.CreateOrganizationUserParams{
+			OrganizationID: organizationID,
+			UserID:         userID,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/src/adapter/infrastructure/organization.go
+++ b/src/adapter/infrastructure/organization.go
@@ -9,6 +9,44 @@ import (
 	"github.com/yuorei/yuorei-ads/src/domain"
 )
 
+func (i *Infrastructure) DBGetOrganization(ctx context.Context, organizationID string) (*domain.Organization, error) {
+	organization, err := i.db.Database.GetOrganization(ctx,
+		organizationID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &domain.Organization{
+		ID:                   organization.OrganizationID,
+		OrganizationName:     organization.OrganizationName,
+		RepresentativeUserID: organization.RepresentativeUserID,
+		Purpose:              organization.Purpose,
+		Category:             organization.Category,
+		CreatedAt:            organization.CreatedAt,
+		UpdatedAt:            organization.UpdatedAt,
+	}, nil
+}
+
+func (i *Infrastructure) DBGetOrganizationByUserID(ctx context.Context, userID string) (*domain.Organization, error) {
+	organization, err := i.db.Database.GetOrganizationByUserID(ctx,
+		userID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &domain.Organization{
+		ID:                   organization.OrganizationID,
+		OrganizationName:     organization.OrganizationName,
+		RepresentativeUserID: organization.RepresentativeUserID,
+		Purpose:              organization.Purpose,
+		Category:             organization.Category,
+		CreatedAt:            organization.CreatedAt,
+		UpdatedAt:            organization.UpdatedAt,
+	}, nil
+}
+
 func (i *Infrastructure) DBCreateOrganization(ctx context.Context, organizationID, clientID, ClientSecret, userID string) (*domain.Organization, error) {
 	organization := &domain.Organization{}
 	hit, err := i.getFromRedis(ctx, clientID+"_"+ClientSecret, organization)

--- a/src/adapter/presentation/ads.go
+++ b/src/adapter/presentation/ads.go
@@ -23,6 +23,26 @@ func NewAdsServer(repository *usecase.Repository) *AdsServer {
 	}
 }
 
+func (s *AdsServer) GetCampaign(ctx context.Context, req *connect.Request[adsv1.GetCampaignRequest]) (*connect.Response[adsv1.GetCampaignResponse], error) {
+	campaign, err := s.usecase.GetCampaign(ctx, req.Msg.CampaignId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get campaign: %w", err)
+	}
+
+	res := connect.NewResponse(&adsv1.GetCampaignResponse{
+		Campaign: &adsv1.Campaign{
+			CampaignId: campaign.CampaignID,
+			UserId:     campaign.UserID,
+			Name:       campaign.Name,
+			Budget:     int32(campaign.Budget),
+			StartDate:  campaign.StartDate.Format("2006-01-02"),
+			EndDate:    campaign.EndDate.Format("2006-01-02"),
+			IsApproval: campaign.IsApproval,
+		},
+	})
+	return res, nil
+}
+
 func (s *AdsServer) ListCampaignByOrganizationID(ctx context.Context, req *connect.Request[adsv1.ListCampaignByOrganizationIDRequest]) (*connect.Response[adsv1.ListCampaignByOrganizationIDResponse], error) {
 	userID, ok := ctx.Value("uid").(string)
 	if !ok || userID == "" {

--- a/src/adapter/presentation/ads.go
+++ b/src/adapter/presentation/ads.go
@@ -129,13 +129,19 @@ func (s *AdsServer) ListAdminAds(ctx context.Context, req *connect.Request[adsv1
 
 	var adList []*adsv1.Ad
 	for _, ad := range ads {
+		var deleteAt *timestamppb.Timestamp
+		if ad.DeleteAt == nil {
+			deleteAt = nil
+		} else {
+			deleteAt = timestamppb.New(*ad.DeleteAt)
+		}
 		adList = append(adList, &adsv1.Ad{
 			AdId:       ad.AdID,
 			CampaignId: ad.CampaignID,
 			AdType:     ad.AdType,
 			CreatedAt:  timestamppb.New(ad.CreatedAt),
 			UpdatedAt:  timestamppb.New(ad.UpdatedAt),
-			DeletedAt:  timestamppb.New(*ad.DeleteAt),
+			DeletedAt:  deleteAt,
 			IsApproval: ad.IsApproval,
 			IsOpen:     ad.IsOpen,
 			AdLink:     ad.AdLink,
@@ -161,13 +167,19 @@ func (s *AdsServer) ListAdsByCampaignID(ctx context.Context, req *connect.Reques
 
 	var adList []*adsv1.Ad
 	for _, ad := range ads {
+		var deleteAt *timestamppb.Timestamp
+		if ad.DeleteAt == nil {
+			deleteAt = nil
+		} else {
+			deleteAt = timestamppb.New(*ad.DeleteAt)
+		}
 		adList = append(adList, &adsv1.Ad{
 			AdId:       ad.AdID,
 			CampaignId: ad.CampaignID,
 			AdType:     ad.AdType,
 			CreatedAt:  timestamppb.New(ad.CreatedAt),
 			UpdatedAt:  timestamppb.New(ad.UpdatedAt),
-			DeletedAt:  timestamppb.New(*ad.DeleteAt),
+			DeletedAt:  deleteAt,
 			IsApproval: ad.IsApproval,
 			IsOpen:     ad.IsOpen,
 			AdLink:     ad.AdLink,

--- a/src/adapter/presentation/organization.go
+++ b/src/adapter/presentation/organization.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	organizationv1 "github.com/yuorei/yuorei-ads-proto/gen/rpc/organization/v1"
 	"github.com/yuorei/yuorei-ads/src/domain"
@@ -20,6 +21,56 @@ func NewOrganizationServer(repository *usecase.Repository) *OrganizationServer {
 	return &OrganizationServer{
 		usecase: usecase.NewUseCase(repository),
 	}
+}
+
+func (s *OrganizationServer) GetOrganization(ctx context.Context, req *connect.Request[organizationv1.GetOrganizationRequest]) (*connect.Response[organizationv1.GetOrganizationResponse], error) {
+	userID, ok := ctx.Value("uid").(string)
+	if !ok || userID == "" {
+		return nil, connect.NewError(connect.CodePermissionDenied, fmt.Errorf("failed to get userID"))
+	}
+
+	result, err := s.usecase.GetOrganization(ctx, req.Msg.OrganizationId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get organization: %w", err)
+	}
+
+	res := connect.NewResponse(&organizationv1.GetOrganizationResponse{
+		Organization: &organizationv1.Organization{
+			OrganizationId:   result.ID,
+			OrganizationName: result.OrganizationName,
+			Purpose:          result.Purpose,
+			Category:         result.Category,
+			CreatedAt:        timestamppb.New(result.CreatedAt),
+			UpdatedAt:        timestamppb.New(result.UpdatedAt),
+		},
+	})
+
+	return res, nil
+}
+
+func (s *OrganizationServer) GetOrganizationByUserID(ctx context.Context, req *connect.Request[organizationv1.GetOrganizationByUserIDRequest]) (*connect.Response[organizationv1.GetOrganizationByUserIDResponse], error) {
+	userID, ok := ctx.Value("uid").(string)
+	if !ok || userID == "" {
+		return nil, connect.NewError(connect.CodePermissionDenied, fmt.Errorf("failed to get userID"))
+	}
+
+	result, err := s.usecase.GetOrganizationByUserID(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get organization: %w", err)
+	}
+
+	res := connect.NewResponse(&organizationv1.GetOrganizationByUserIDResponse{
+		Organization: &organizationv1.Organization{
+			OrganizationId:   result.ID,
+			OrganizationName: result.OrganizationName,
+			Purpose:          result.Purpose,
+			Category:         result.Category,
+			CreatedAt:        timestamppb.New(result.CreatedAt),
+			UpdatedAt:        timestamppb.New(result.UpdatedAt),
+		},
+	})
+
+	return res, nil
 }
 
 func (s *OrganizationServer) CreateOrganization(ctx context.Context, req *connect.Request[organizationv1.CreateOrganizationRequest]) (*connect.Response[organizationv1.CreateOrganizationResponse], error) {

--- a/src/adapter/presentation/rest/file.go
+++ b/src/adapter/presentation/rest/file.go
@@ -183,7 +183,7 @@ func (h *Handler) UploadAdVideoHandler(w http.ResponseWriter, r *http.Request) {
 		// フォームからAdVideoMetaの情報を取得
 		title := r.FormValue("title")
 		description := r.FormValue("description")
-		thumbnailImageUrl := r.FormValue("thumbnail_image_url")
+		// thumbnailImageUrl := r.FormValue("thumbnail_image_url")
 		tagString := r.FormValue("tags")
 		tags := strings.Split(tagString, ",")
 		campaignID := r.FormValue("campaign_id")
@@ -192,12 +192,13 @@ func (h *Handler) UploadAdVideoHandler(w http.ResponseWriter, r *http.Request) {
 		adID := domain.NewAdID()
 		ad := domain.NewAd(adID, campaignID, "video", false, false, adLink, tags, time.Now(), time.Now(), nil)
 
-		// TODO: 動画URL、サムネイルURL修正
-		adVideo := domain.NewAdVideo(adID, title, description, "videoURL", thumbnailImageUrl, time.Now(), time.Now(), nil)
+		videoURL := fmt.Sprintf("%s/video/%s/output_%s.m3u8", os.Getenv("S3_URL"), adID, adID)
+		thumbnailImageUrl := fmt.Sprintf("%s/%s/%s.webp", os.Getenv("S3_URL"), "thumbnail-image", adID)
+		adVideo := domain.NewAdVideo(adID, title, description, videoURL, thumbnailImageUrl, time.Now(), time.Now(), nil)
 
 		adResult, err := h.usecase.AdsInputPort.CreateAdVideo(ctx, ad, adVideo, userID, uploadID, videoType, imageType)
 		if err != nil {
-			http.Error(w, "Unable to process video meta", http.StatusInternalServerError)
+			http.Error(w, "Unable to process video meta: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 

--- a/src/usecase/ads.go
+++ b/src/usecase/ads.go
@@ -18,6 +18,15 @@ func NewAdsRepository(adsRepository port.AdsRepository) *AdsUseCase {
 	}
 }
 
+func (r *Repository) GetCampaign(ctx context.Context, campaignID string) (*domain.Campaign, error) {
+	result, err := r.adsRepository.adsRepository.DBGetCampaign(ctx, campaignID)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 func (r *Repository) CheckOrganizationID(ctx context.Context, organizationID, userID string) error {
 	err := r.adsRepository.adsRepository.DBCheckOrganizationID(ctx, organizationID, userID)
 	if err != nil {

--- a/src/usecase/organization.go
+++ b/src/usecase/organization.go
@@ -17,6 +17,24 @@ func NewOrganizationRepository(organizationRepository port.OrganizationRepositor
 	}
 }
 
+func (u *Repository) GetOrganization(ctx context.Context, organizationID string) (*domain.Organization, error) {
+	result, err := u.organizationRepository.organizationRepository.DBGetOrganization(ctx, organizationID)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (u *Repository) GetOrganizationByUserID(ctx context.Context, userID string) (*domain.Organization, error) {
+	result, err := u.organizationRepository.organizationRepository.DBGetOrganizationByUserID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 func (r *Repository) CreateOrganization(ctx context.Context, organizationID, clientID, ClientSecret, userID string) (*domain.Organization, error) {
 	result, err := r.organizationRepository.organizationRepository.DBCreateOrganization(ctx, organizationID, clientID, ClientSecret, userID)
 	if err != nil {

--- a/src/usecase/organization.go
+++ b/src/usecase/organization.go
@@ -32,6 +32,11 @@ func (r *Repository) CreateOrganization(ctx context.Context, organizationID, cli
 		return nil, err
 	}
 
+	err = r.organizationRepository.organizationRepository.DBCreateOrganizationUser(ctx, result.ID, result.RepresentativeUserID)
+	if err != nil {
+		return nil, err
+	}
+
 	return result, nil
 }
 

--- a/src/usecase/port/ads_port.go
+++ b/src/usecase/port/ads_port.go
@@ -8,13 +8,14 @@ import (
 )
 
 type AdsInputPort interface {
-	GetAd(context.Context, string) (*domain.Ad, error)
+	GetCampaign(context.Context, string) (*domain.Campaign, error)
 	CheckOrganizationID(context.Context, string, string) error
 	ListCampaignByOrganizationID(context.Context, string, int, int) ([]*domain.Campaign, error)
 	CreateCampaign(context.Context, *domain.Campaign) (*domain.Campaign, error)
 	ListAdminAds(context.Context, string, int, int) ([]*domain.Ad, error)
 	ListAdsByCampaignID(context.Context, string, int, int) ([]*domain.Ad, error)
 
+	GetAd(context.Context, string) (*domain.Ad, error)
 	CreateAdVideo(context.Context, *domain.Ad, *domain.AdVideo, string, string, string, string) (*domain.Ad, error)
 	GetAdVideos(context.Context, *domain.GetAdVideoRequest) ([]*domain.AdVideoResponse, error)
 	WatchCountAdVideo(context.Context, *domain.WatchCountAdVideo) error
@@ -22,6 +23,7 @@ type AdsInputPort interface {
 }
 
 type AdsRepository interface {
+	DBGetCampaign(context.Context, string) (*domain.Campaign, error)
 	DBGetAd(context.Context, string) (*domain.Ad, error)
 	DBCheckOrganizationID(context.Context, string, string) error
 	DBListCampaignByOrganizationID(context.Context, string, int, int) ([]*domain.Campaign, error)

--- a/src/usecase/port/organization_port.go
+++ b/src/usecase/port/organization_port.go
@@ -14,4 +14,5 @@ type OrganizationInputPort interface {
 type OrganizationRepository interface {
 	DBCreateOrganization(ctx context.Context, organizationID, clientID, ClientSecret, userID string) (*domain.Organization, error)
 	TmpSaveRedisCreateOrganization(ctx context.Context, organization *domain.Organization, clientID, ClientSecret string) (*domain.Organization, error)
+	DBCreateOrganizationUser(ctx context.Context, organizationID, userID string) error
 }

--- a/src/usecase/port/organization_port.go
+++ b/src/usecase/port/organization_port.go
@@ -7,11 +7,15 @@ import (
 )
 
 type OrganizationInputPort interface {
+	GetOrganization(ctx context.Context, organizationID string) (*domain.Organization, error)
+	GetOrganizationByUserID(ctx context.Context, userID string) (*domain.Organization, error)
 	CreateOrganization(ctx context.Context, organizationID, clientID, ClientSecret, userID string) (*domain.Organization, error)
 	CreateTmpOrganization(ctx context.Context, organization *domain.Organization, clientID, ClientSecret string) (*domain.Organization, error)
 }
 
 type OrganizationRepository interface {
+	DBGetOrganization(ctx context.Context, organizationID string) (*domain.Organization, error)
+	DBGetOrganizationByUserID(ctx context.Context, userID string) (*domain.Organization, error)
 	DBCreateOrganization(ctx context.Context, organizationID, clientID, ClientSecret, userID string) (*domain.Organization, error)
 	TmpSaveRedisCreateOrganization(ctx context.Context, organization *domain.Organization, clientID, ClientSecret string) (*domain.Organization, error)
 	DBCreateOrganizationUser(ctx context.Context, organizationID, userID string) error


### PR DESCRIPTION
このプル リクエストでは、キャンペーンと組織を処理するためのデータベース クエリとインフラストラクチャにいくつかの新機能と改善が導入されています。また、いくつかのマイナーなコードのクリーンアップと改善も含まれています。

### データベース クエリの強化:
* `campaign_id` でキャンペーンの詳細を取得するための新しいクエリ `GetCampaign` を追加し、対応するメソッドを `db/sqlc/ads.sql.go` に実装しました。
* `organization_id` と `user_id` で組織の詳細を取得するためのクエリ `GetOrganization` と `GetOrganizationByUserID` を追加し、対応するメソッドを `db/sqlc/organization.sql.go` に実装しました。

### インフラストラクチャの強化:
* `src/adapter/infrastructure/ads.go` に `DBGetCampaign` メソッドを実装し、データベースからキャンペーンの詳細を取得しました。
* データベースから組織の詳細を取得するために、`src/adapter/infrastructure/organization.go` に `DBGetOrganization` メソッドと `DBGetOrganizationByUserID` メソッドを実装しました。

### プレゼンテーション レイヤーの強化:
* キャンペーンの詳細のリクエストを処理するために、`src/adapter/presentation/ads.go` に `GetCampaign` メソッドを追加しました。
* 組織の詳細のリクエストを処理するために、`src/adapter/presentation/organization.go` に `GetOrganization` メソッドと `GetOrganizationByUserID` メソッドを追加しました。

### コードのクリーンアップ:
* コードをクリーンアップするために、`src/adapter/infrastructure/ads.go` から不要な `fmt.Println` ステートメントを削除しました。 [[1]](diffhunk://#diff-165135ec703a1718e0e10f79c4ab510a46328a705c926a7198cb9dca3df891d1L193-R212) [[2]](diffhunk://#diff-165135ec703a1718e0e10f79c4ab510a46328a705c926a7198cb9dca3df891d1L217-R244) [[3]](diffhunk://#diff-165135ec703a1718e0e10f79c4ab510a46328a705c926a7198cb9dca3df891d1L246-R265) [[4]](diffhunk://#diff-165135ec703a1718e0e10f79c4ab510a46328a705c926a7198cb9dca3df891d1L298-R317)

### 依存関係の更新:
* `go.mod` の `github.com/yuorei/yuorei-ads-proto` のバージョンを更新しました。