### PR TITLE
Add Dockerfile for building and running the ads server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.23
+WORKDIR /src
+COPY . .
+
+RUN go build -o /bin/ads ./cmd/server/main.go
+
+FROM scratch
+COPY --from=0 /bin/ads /bin/ads
+CMD ["/bin/ads"]


### PR DESCRIPTION
This pull request introduces a new `Dockerfile` to the project, which sets up a multi-stage build for a Go application. The most important changes include specifying the base image, copying the source code, building the application, and creating a minimal final image.

Key changes:

* `Dockerfile`: 
  * Set the base image to `golang:1.23` and define the working directory.
  * Copy the source code into the container and build the application using `go build`.
  * Create a minimal final image by copying the built executable from the first stage and setting the command to run the application.